### PR TITLE
fix: address all 6 security code-scanning alerts

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2354,7 +2354,8 @@ async def test_paperless_connection() -> JSONResponse:
     except httpx.TimeoutException:
         return JSONResponse(content={"status": "error", "detail": "Connection to Paperless NGX timed out."})
     except Exception as exc:
-        return JSONResponse(content={"status": "error", "detail": str(exc)})
+        logger.exception("Connection test failed unexpectedly: %s", exc)
+        return JSONResponse(content={"status": "error", "detail": "An unexpected error occurred. Check server logs for details."})
 
 
 # ---------------------------------------------------------------------------
@@ -3023,7 +3024,12 @@ async def register_webhook(request: Request) -> dict:
             "actions": actions,
         }
 
-        logger.info("Webhook register — sending payload: %s", payload)
+        _safe_actions = [
+            {**a, "webhook": {**a["webhook"], "url": _re.sub(r"(key=)[^&]*", r"\1[REDACTED]", a["webhook"]["url"])}}
+            if a.get("webhook") else a
+            for a in payload.get("actions", [])
+        ]
+        logger.info("Webhook register — sending payload: %s", {**payload, "actions": _safe_actions})
 
         if existing_id is not None:
             r = await client.put(
@@ -3054,7 +3060,9 @@ async def register_webhook(request: Request) -> dict:
             )
 
     logger.info(
-        "Webhook workflow %s (callback: %s).", verb, callback_url
+        "Webhook workflow %s (callback: %s).",
+        verb,
+        _re.sub(r"(key=)[^&]*", r"\1[REDACTED]", callback_url),
     )
     return {
         "detail": f"Workflow '{_PAPERLESS_IQ_WORKFLOW_NAME}' {verb}.",
@@ -3381,8 +3389,12 @@ if _FRONTEND_DIR.is_dir():
         JS/CSS assets use content-hash filenames and are served by the /assets
         StaticFiles mount — those can be cached indefinitely.
         """
-        file_path = _FRONTEND_DIR / full_path
-        if file_path.is_file() and full_path != "index.html":
+        file_path = (_FRONTEND_DIR / full_path).resolve()
+        if (
+            file_path.is_relative_to(_FRONTEND_DIR)
+            and file_path.is_file()
+            and full_path != "index.html"
+        ):
             return FileResponse(file_path)
         html = (_FRONTEND_DIR / "index.html").read_text(encoding="utf-8")
         return HTMLResponse(content=html, headers={"Cache-Control": "no-store"})

--- a/backend/settings_service.py
+++ b/backend/settings_service.py
@@ -398,8 +398,11 @@ class SettingsService:
                 PaperlessIQConfig(**test_data)
                 valid_values[key] = value
                 applied.append(key)
-            except (ValidationError, ValueError) as exc:
-                skipped.append({"field": key, "reason": str(exc)})
+            except ValidationError as exc:
+                reasons = [e["msg"] for e in exc.errors()[:3]]
+                skipped.append({"field": key, "reason": "; ".join(reasons)})
+            except ValueError:
+                skipped.append({"field": key, "reason": "Invalid value for this field"})
 
         if valid_values:
             current = self._config.model_dump()


### PR DESCRIPTION
## Summary

- **#1 / py/stack-trace-exposure** — generic catch-all in `test_paperless_connection` logs exception server-side, returns a safe message to the caller
- **#2 / py/stack-trace-exposure** — `import_config` no longer propagates raw `str(exc)` to API callers; ValidationError messages extracted via `exc.errors()`, ValueError yields a static string
- **#3 & #4 / py/clear-text-logging-sensitive-data** — webhook `key=` query parameter redacted to `[REDACTED]` in both the payload log and the callback-URL log
- **#5 & #6 / py/path-injection** — SPA catch-all resolves the path and verifies `is_relative_to(_FRONTEND_DIR)` before serving, blocking directory traversal

## Test plan
- [x] All 195 existing tests pass (`uv run pytest`)
- [x] No new TypeScript errors (`npx tsc --noEmit`)

Closes security alerts #1, #2, #3, #4, #5, #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)