### PR TITLE
fix: use constant instead of payload dict key in webhook log

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3026,7 +3026,7 @@ async def register_webhook(request: Request) -> dict:
 
         logger.info(
             "Webhook register — name=%r triggers=%d actions=%d existing_id=%s",
-            payload["name"], len(triggers), len(actions), existing_id,
+            _PAPERLESS_IQ_WORKFLOW_NAME, len(triggers), len(actions), existing_id,
         )
 
         if existing_id is not None:


### PR DESCRIPTION
## Summary

CodeQL traces the entire `payload` dict as tainted (it contains the `actions` array with the webhook URL including the secret). Even accessing `payload["name"]` is flagged as clear-text logging of sensitive data.

Fix: replace `payload["name"]` with the module constant `_PAPERLESS_IQ_WORKFLOW_NAME` in the log call, which is not part of the taint flow.

Closes alert #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)