### PR TITLE
fix: Cohere Embed v4 on Bedrock + refuse unknown embed models

### DIFF
--- a/backend/providers/bedrock.py
+++ b/backend/providers/bedrock.py
@@ -212,24 +212,46 @@ class BedrockProvider:
         Supported model families and their request/response formats:
           - amazon.titan-embed-text-v1   : inputText → embedding[]  (1536-dim)
           - amazon.titan-embed-text-v2:0 : inputText → embedding[]  (1024-dim default)
-          - cohere.embed-english-v3      : texts[]   → embeddings[][] (1024-dim)
-          - cohere.embed-multilingual-v3 : texts[]   → embeddings[][] (1024-dim)
+          - cohere.embed-english-v3      : texts[]   → embeddings[][]        (1024-dim)
+          - cohere.embed-multilingual-v3 : texts[]   → embeddings[][]        (1024-dim)
+          - cohere.embed-v4:0            : texts[]   → embeddings[][] or     (1536-dim)
+                                           embeddings{type:[][]} by response_type
+
+        The family is matched as a substring, not a prefix: cross-Region
+        inference-profile IDs prepend a region group (e.g. "eu.cohere.embed-v4:0",
+        "us.amazon.titan-..."), and v4 in particular is only invokable through an
+        inference profile. A prefix check would misroute those to the wrong body.
         """
         model = self._embed_model
 
-        is_cohere = model.startswith("cohere.")
-        is_titan_v2 = model == "amazon.titan-embed-text-v2:0"
+        is_cohere = "cohere." in model
+        is_titan_v2 = "titan-embed-text-v2" in model
 
         if is_cohere:
             # Cohere expects a list of texts; input_type "search_document" optimises
             # for retrieval (use "search_query" when embedding a query instead).
+            # This body is valid for both Embed v3 and v4 — embedding_types is left
+            # unset so v4 returns float vectors; the parser below handles both the
+            # flat ("embeddings_floats") and keyed ("embeddings_by_type") shapes.
             body = json.dumps({"texts": [text], "input_type": "search_document"})
         elif is_titan_v2:
             # Titan v2 supports normalisation and configurable dimensions (256/512/1024)
             body = json.dumps({"inputText": text, "dimensions": 1024, "normalize": True})
-        else:
-            # Titan v1 (and any unknown Titan variant)
+        elif "titan-embed" in model:
+            # Titan v1 and older Titan embed variants
             body = json.dumps({"inputText": text})
+        else:
+            # Refuse unknown models rather than silently sending the Titan body —
+            # that would produce wrong embeddings (or a cryptic provider error) with
+            # no signal. Raising surfaces it in the "Embedding paused" banner so the
+            # user can pick a supported model instead.
+            raise ValueError(
+                f"Unsupported Bedrock embedding model '{model}'. Supported families: "
+                "amazon.titan-embed-text-v1, amazon.titan-embed-text-v2:0, "
+                "cohere.embed-english-v3, cohere.embed-multilingual-v3, cohere.embed-v4:0 "
+                "(or their cross-Region inference-profile IDs). "
+                "Set a supported model in Settings → AI Provider."
+            )
 
         loop = asyncio.get_running_loop()
 
@@ -256,7 +278,15 @@ class BedrockProvider:
                 raise
 
         if is_cohere:
-            return result["embeddings"][0]
+            embeddings = result["embeddings"]
+            if isinstance(embeddings, dict):
+                # v4 "embeddings_by_type": {"float": [[...]], "int8": [[...]]}.
+                # Prefer float; fall back to whatever type was returned.
+                vectors = embeddings.get("float") or next(iter(embeddings.values()))
+            else:
+                # v3 / v4 "embeddings_floats": [[...]]
+                vectors = embeddings
+            return vectors[0]
         return result["embedding"]
 
     async def health_check(self) -> bool:

--- a/tests/test_unit_provider_adapters.py
+++ b/tests/test_unit_provider_adapters.py
@@ -371,6 +371,63 @@ class TestBedrockSDKCalls:
         assert body["inputText"] == "embed this"
         assert result == [0.4, 0.5, 0.6]
 
+    @pytest.mark.asyncio
+    async def test_embed_cohere_v4_via_inference_profile(self, bedrock_provider: BedrockProvider):
+        """A cross-Region inference-profile ID must still route to the Cohere body.
+
+        Regression: a prefix check (model.startswith("cohere.")) misrouted
+        "eu.cohere.embed-v4:0" to the Titan inputText body → "Malformed request".
+        """
+        import json
+        bedrock_provider._embed_model = "eu.cohere.embed-v4:0"
+        mock_body = MagicMock()
+        # v4 text-only default shape: flat "embeddings_floats" list
+        mock_body.read.return_value = json.dumps({
+            "embeddings": [[0.1, 0.2, 0.3]],
+            "response_type": "embeddings_floats",
+        }).encode()
+        mock_client = MagicMock()
+        mock_client.invoke_model.return_value = {"body": mock_body}
+
+        with patch.object(bedrock_provider, "_runtime_client", return_value=mock_client):
+            result = await bedrock_provider.embed("embed this")
+
+        body = json.loads(mock_client.invoke_model.call_args[1]["body"])
+        assert body["texts"] == ["embed this"]          # Cohere body, not Titan
+        assert body["input_type"] == "search_document"
+        assert "inputText" not in body
+        assert result == [0.1, 0.2, 0.3]
+
+    @pytest.mark.asyncio
+    async def test_embed_cohere_v4_embeddings_by_type(self, bedrock_provider: BedrockProvider):
+        """v4 may return embeddings keyed by type — parser must extract the float vector."""
+        import json
+        bedrock_provider._embed_model = "cohere.embed-v4:0"
+        mock_body = MagicMock()
+        mock_body.read.return_value = json.dumps({
+            "embeddings": {"float": [[0.5, 0.6, 0.7]]},
+            "response_type": "embeddings_by_type",
+        }).encode()
+        mock_client = MagicMock()
+        mock_client.invoke_model.return_value = {"body": mock_body}
+
+        with patch.object(bedrock_provider, "_runtime_client", return_value=mock_client):
+            result = await bedrock_provider.embed("embed this")
+
+        assert result == [0.5, 0.6, 0.7]
+
+    @pytest.mark.asyncio
+    async def test_embed_unknown_model_raises_not_silent_titan(self, bedrock_provider: BedrockProvider):
+        """An unrecognized model must raise, never silently use the Titan body."""
+        bedrock_provider._embed_model = "some.unknown-embed-model:0"
+        mock_client = MagicMock()
+
+        with patch.object(bedrock_provider, "_runtime_client", return_value=mock_client):
+            with pytest.raises(ValueError, match="Unsupported Bedrock embedding model"):
+                await bedrock_provider.embed("embed this")
+
+        mock_client.invoke_model.assert_not_called()  # never reached the wrong body
+
 
 # ---------------------------------------------------------------------------
 # 10. SDK call construction — Ollama complete() and embed()


### PR DESCRIPTION
## Context
A user set their Bedrock embed model to `cohere.embed-v4:0` and hit `Invocation of model ID cohere.embed-v4:0 with on-demand throughput isn't supported...`. After setting a cross-Region inference-profile ID to satisfy that, they then got `Malformed request. Please check your parameter/values and try again.`

Root cause: Bedrock's `InvokeModel` passes model-native JSON bodies through, so it's only "unified" at the transport layer — each family (Titan / Cohere v3 / Cohere v4) needs its own request and response handling.

## Fixes
1. **Inference-profile routing.** `is_cohere` now matches `"cohere."` as a substring instead of a prefix. v4 is only invokable via a cross-Region inference profile (e.g. `eu.cohere.embed-v4:0`), and the region prefix made the old `startswith` check misroute the request to the Titan body → "Malformed request". Verified against the [AWS Embed v4 parameters docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-embed-v4.html).
2. **v4 response shape.** v4 can return `embeddings` keyed by type (`embeddings_by_type`: `{"float": [[...]]}`) in addition to v3's flat `embeddings_floats` list. The parser handles both.
3. **Refuse unknown models.** An unrecognized model ID now raises `ValueError` (which surfaces in the "Embedding paused" banner from #20) instead of silently falling through to the Titan body and producing wrong embeddings with no warning.

## Test plan
- [x] `uv run pytest` — 198 pass (+3 new: inference-profile routing, both v4 response shapes, unknown-model refusal asserts `invoke_model` is never called)

## Note for the user
This unblocks v4, but the simplest path remains `cohere.embed-multilingual-v3` (on-demand, no inference profile needed). For v4 you must use an inference-profile model ID, not the raw `cohere.embed-v4:0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)