### PR TITLE
fix: recover from empty alembic_version on startup (boot 502)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -14,9 +14,12 @@ import backend.orm_models  # noqa: F401 — registers all ORM models on Base.met
 # Alembic Config object
 config = context.config
 
-# Set up logging from alembic.ini
+# Set up logging from alembic.ini. disable_existing_loggers=False is essential:
+# this env runs at app startup (via backend.db_migrate.run_migrations), and the
+# default True would silence every logger created before migrations ran —
+# including the app's own module loggers.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # Metadata for autogenerate support
 target_metadata = Base.metadata

--- a/backend/db_migrate.py
+++ b/backend/db_migrate.py
@@ -46,16 +46,31 @@ def _run_migrations_sync() -> None:
     engine = create_engine(sync_url)
     try:
         tables = set(inspect(engine).get_table_names())
+        # Read the current revision directly. The detection below keys off
+        # whether the DB is *stamped at a revision*, not merely whether the
+        # alembic_version table exists: a half-initialised DB can have an empty
+        # alembic_version table (table created, no row committed — SQLite DDL is
+        # non-transactional, so a crashed first migration leaves exactly this).
+        # Treating "table present but empty" as "not stamped" prevents an upgrade
+        # from re-running the baseline CREATE TABLEs against an existing schema.
+        current_rev: str | None = None
+        if "alembic_version" in tables:
+            with engine.connect() as conn:
+                row = conn.exec_driver_sql(
+                    "SELECT version_num FROM alembic_version LIMIT 1"
+                ).fetchone()
+                current_rev = row[0] if row else None
     finally:
         engine.dispose()
 
     cfg = _alembic_config()
 
-    if "alembic_version" not in tables and _SENTINEL_TABLE in tables:
-        # Existing pre-Alembic database: adopt it at the baseline without
-        # re-creating tables, then let upgrade apply anything newer.
+    if current_rev is None and _SENTINEL_TABLE in tables:
+        # Existing pre-Alembic (or half-stamped) database that already holds the
+        # schema: adopt it at the baseline without re-creating tables, then let
+        # upgrade apply anything newer.
         logger.info(
-            "Existing pre-Alembic database detected — stamping baseline %s",
+            "Existing un-stamped database detected — stamping baseline %s",
             _BASELINE_REVISION,
         )
         command.stamp(cfg, _BASELINE_REVISION)

--- a/tests/test_unit_db_migrate.py
+++ b/tests/test_unit_db_migrate.py
@@ -1,0 +1,110 @@
+"""Unit tests for the startup Alembic migration runner.
+
+Covers the three database states the runner must handle on boot:
+  1. Brand-new DB              → build the schema, stamp head.
+  2. Pre-Alembic DB            → sentinel table exists, no alembic_version → stamp.
+  3. Half-stamped/wedged DB    → alembic_version table exists but is *empty*.
+
+State 3 is the regression: SQLite's non-transactional DDL means a first
+migration that crashes can leave an empty alembic_version table. A naive
+"stamp only when the table is absent" check then lets ``upgrade`` re-run the
+baseline CREATE TABLEs against the existing schema, crash-looping the app.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+import backend.database as database
+import backend.db_migrate as db_migrate
+
+
+def _run_migrations() -> None:
+    """Run the migration sync routine in a worker thread, as production does.
+
+    ``run_migrations`` dispatches ``_run_migrations_sync`` via run_in_executor, so
+    Alembic's internal ``asyncio.run`` always executes on a loop-less worker
+    thread. Calling it directly from the test's main thread instead would churn
+    the event loop that pytest-asyncio manages for other tests. Mirroring the
+    production threading keeps this test from polluting later async tests.
+    """
+    error: dict[str, BaseException] = {}
+
+    def target() -> None:
+        try:
+            db_migrate._run_migrations_sync()
+        except BaseException as exc:  # noqa: BLE001 — re-raised on the main thread
+            error["exc"] = exc
+
+    thread = threading.Thread(target=target)
+    thread.start()
+    thread.join()
+    if "exc" in error:
+        raise error["exc"]
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    """Point both the runner and Alembic's env at an isolated temp SQLite file."""
+    db_path = tmp_path / "piq.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setattr(database, "DATABASE_URL", url)
+    monkeypatch.setattr(db_migrate, "DATABASE_URL", url)
+    return db_path
+
+
+def _current_revision(db_path) -> str | None:
+    con = sqlite3.connect(db_path)
+    try:
+        row = con.execute("SELECT version_num FROM alembic_version LIMIT 1").fetchone()
+        return row[0] if row else None
+    finally:
+        con.close()
+
+
+def _table_names(db_path) -> set[str]:
+    con = sqlite3.connect(db_path)
+    try:
+        return {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    finally:
+        con.close()
+
+
+def test_fresh_db_migrates_to_head(temp_db):
+    _run_migrations()
+
+    assert _current_revision(temp_db) == db_migrate._BASELINE_REVISION
+    assert db_migrate._SENTINEL_TABLE in _table_names(temp_db)
+
+
+def test_pre_alembic_db_is_stamped_not_recreated(temp_db):
+    # Sentinel table present, no alembic_version at all (classic pre-Alembic DB).
+    con = sqlite3.connect(temp_db)
+    con.execute(f"CREATE TABLE {db_migrate._SENTINEL_TABLE} (id INTEGER PRIMARY KEY)")
+    con.commit()
+    con.close()
+
+    _run_migrations()  # must not raise re-creating the table
+
+    assert _current_revision(temp_db) == db_migrate._BASELINE_REVISION
+
+
+def test_empty_alembic_version_is_restamped(temp_db):
+    """Regression: an existing schema with an empty alembic_version must re-stamp,
+    not re-run the baseline migration."""
+    # Build the full schema and stamp head…
+    _run_migrations()
+    # …then wedge it: table exists but holds no revision row.
+    con = sqlite3.connect(temp_db)
+    con.execute("DELETE FROM alembic_version")
+    con.commit()
+    con.close()
+    assert _current_revision(temp_db) is None
+
+    # Second boot must recover cleanly rather than crash on CREATE TABLE.
+    _run_migrations()
+
+    assert _current_revision(temp_db) == db_migrate._BASELINE_REVISION


### PR DESCRIPTION
## Problem

On first boot after adopting Alembic (#22), a container can **crash-loop with a 502 and no traceback**.

Root cause: a database whose `alembic_version` table **exists but holds no revision row** (e.g. a first migration that crashed mid-run — SQLite DDL is non-transactional, so the version row is never committed) was treated as *already stamped*. `upgrade head` then re-ran the baseline `CREATE TABLE`s against the already-present schema → collision → exit 3 → infinite restart loop.

A second bug hid the error: `alembic/env.py` reconfigured logging with the default `disable_existing_loggers=True`, silencing the app's own loggers during the boot migration — which is why the crash produced no traceback.

## Fix

- **`backend/db_migrate.py`** — stamp the baseline whenever there is **no current revision** (table empty *or* absent), not only when the `alembic_version` table is missing.
- **`backend/alembic/env.py`** — `fileConfig(..., disable_existing_loggers=False)` so startup migrations stop muting application logging.
- **`tests/test_unit_db_migrate.py`** — regression coverage for fresh / pre-Alembic / empty-version boot states. Runs the migration in a worker thread to mirror production and avoid polluting pytest-asyncio's event loop.

## Recovery for an already-wedged DB (no rebuild)

Stamp the empty table with the baseline revision (`f4d9771c79eb`, currently = head), after backing up the DB. This makes `upgrade` a no-op and the container boots normally.

## Testing

- Full backend suite: **207 passed**, ruff clean.
- Verified on a live wedged database: container went from crash-loop → serving HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)