### PR TITLE
ci: group @mantine/* in Dependabot to fix peer-dep conflicts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    groups:
+      # @mantine/core pins an exact peer on @mantine/hooks, so split PRs
+      # produce an ERESOLVE conflict. Always bump the pair together.
+      mantine:
+        patterns:
+          - "@mantine/*"
 
   # uv/pip — Python backend dependencies
   - package-ecosystem: "uv"


### PR DESCRIPTION
## Why
`@mantine/core` pins an **exact** peer on `@mantine/hooks` (core@9.3.2 → hooks@9.3.2). Dependabot opens these as two separate PRs ([#28](https://github.com/knows-cloud/paperless-iq/pull/28), [#30](https://github.com/knows-cloud/paperless-iq/pull/30)), so each bumps only half the pair and CI fails with:

```
peer @mantine/hooks@"9.3.0" from @mantine/core@9.3.0
Conflicting peer dependency: @mantine/hooks@9.3.0
```

## Change
Adds a `mantine` group to the npm ecosystem so `@mantine/*` packages are always bumped together in a single PR.

## Follow-up
After this lands, #28 and #30 should be closed; Dependabot will re-open a combined `@mantine/*` PR on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)