### PR TITLE
fix(ci): wiki-sync sidebar fails under bash (printf leading-dash)

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -77,22 +77,30 @@ jobs:
           ARCHITECTURE|Architecture
           "
 
-          : > wiki/_Sidebar.md
-          printf '### Paperless IQ\n' >> wiki/_Sidebar.md
-          printf '- [[Home]]\n\n' >> wiki/_Sidebar.md
-          printf '### User Guide\n' >> wiki/_Sidebar.md
-          printf '- [[Getting-Started]]\n' >> wiki/_Sidebar.md
-          printf '- [[Document-Analysis]]\n' >> wiki/_Sidebar.md
-          printf '- [[Discovery]]\n' >> wiki/_Sidebar.md
-          printf '- [[Automation]]\n' >> wiki/_Sidebar.md
-          printf '- [[Grooming]]\n' >> wiki/_Sidebar.md
-          printf '\n### Reference\n' >> wiki/_Sidebar.md
-          printf '- [[LLM-Providers]]\n' >> wiki/_Sidebar.md
-          printf '- [[Vector-Stores]]\n' >> wiki/_Sidebar.md
-          printf '- [[Settings]]\n' >> wiki/_Sidebar.md
-          printf '- [[Troubleshooting]]\n' >> wiki/_Sidebar.md
-          printf '\n### Developer\n' >> wiki/_Sidebar.md
-          printf '- [[Architecture]]\n' >> wiki/_Sidebar.md
+          # Build the sidebar with `printf '%s\n'` and one argument per line.
+          # Do NOT use `printf '- [[Home]]\n'`: a format string beginning with
+          # "- " is parsed as an option flag under bash and aborts the job
+          # ("printf: - : invalid option"). A '%s\n' format is immune.
+          printf '%s\n' \
+            '### Paperless IQ' \
+            '- [[Home]]' \
+            '' \
+            '### User Guide' \
+            '- [[Getting-Started]]' \
+            '- [[Document-Analysis]]' \
+            '- [[Discovery]]' \
+            '- [[Automation]]' \
+            '- [[Grooming]]' \
+            '' \
+            '### Reference' \
+            '- [[LLM-Providers]]' \
+            '- [[Vector-Stores]]' \
+            '- [[Settings]]' \
+            '- [[Troubleshooting]]' \
+            '' \
+            '### Developer' \
+            '- [[Architecture]]' \
+            > wiki/_Sidebar.md
 
           echo "$PAGES" | while IFS='|' read -r src page; do
             src="${src// /}"


### PR DESCRIPTION
## Problem

The full wiki documentation (9 pages) was merged in #27, but **it never appeared in the GitHub Wiki**. The `wiki-sync` run triggered by that merge [failed](https://github.com/knows-cloud/paperless-iq/actions):

```
line 82: printf: - : invalid option
```

The `_Sidebar.md` generation used `printf '- [[Home]]\n'`. Under **bash** (the CI shell), a `printf` format string that begins with `-` is parsed as an option flag and the job aborts before any page is copied or pushed. It happened to work in local `zsh` testing, which is why it slipped through.

## Fix

Rewrite the sidebar generation as `printf '%s\n'` with one argument per line. The format string starts with `%`, never `-`, so it can't be misparsed — and unlike a heredoc, it doesn't re-indent the markdown inside the YAML `run:` block.

Verified the corrected form produces the right output under `bash`. All 11 source docs the workflow copies exist in `docs/`.

## After merge

Merging this touches `.github/workflows/wiki-sync.yml` (in the workflow's own trigger paths), so the sync runs automatically and publishes the Wiki. Can also be re-run manually via **Actions → Sync docs to Wiki → Run workflow**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)