### PR TITLE
chore: fix ruff lint errors and enforce lint gates in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Audit Python dependencies
         run: uvx pip-audit
 
+      - name: Lint backend (ruff)
+        run: uv run ruff check backend
+
+      - name: Security scan backend (bandit)
+        run: uv run bandit -rq backend --severity-level medium
+
       - name: Run pytest
         run: uv run pytest -q
 
@@ -64,6 +70,9 @@ jobs:
 
       - name: TypeScript check
         run: npx tsc --noEmit
+
+      - name: Lint (eslint)
+        run: npm run lint
 
       - name: i18n completeness check
         run: npm run check:i18n

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,12 +106,23 @@ frontend/src/
 
 ---
 
-## Before You Commit
+## Before You Commit / Push
+
+Run the lint, typecheck, and test gates locally **before pushing to GitHub** and
+fix anything they surface — do not rely on CI to catch it. Note that CI's backend
+job historically ran only pip-audit + pytest, so a green CI does **not** prove the
+backend is ruff-clean; always run ruff yourself.
 
 1. `npx tsc --noEmit` from `frontend/` — zero errors required
-2. `ruff check backend` — zero errors required (config in `pyproject.toml`)
-3. `uv run pytest` — must not introduce new failures (note: the property suite is currently flaky from cross-test state pollution — a different test may fail per run but each passes in isolation)
-4. `npm run check:i18n` from `frontend/` — all 5 locale files must have identical key sets
-5. If you changed the DB schema, generate an Alembic migration (`alembic revision --autogenerate`) — never inline `ALTER`/`create_all` (see D-21)
-6. If you changed a design decision, update `docs/DECISIONS.md`
-7. If you changed the module structure, update `docs/ARCHITECTURE.md`
+2. `npm run lint` from `frontend/` — eslint (`eslint src`); catches React-hooks/code-quality issues `tsc` misses. Zero errors required (warnings are tolerated but should trend down)
+3. `ruff check backend` — zero errors required (config in `pyproject.toml`); use `--fix` for autofixable lints
+4. `uv run bandit -rq backend --severity-level medium` — security linter; finds smells ruff's default rules don't (hardcoded secrets, `shell=True`, weak crypto). Zero medium/high findings required. (Plain `bandit -rq backend` also flags 12 intentional Low `try/except/pass` (B110) — those are accepted, hence the `medium` gate.)
+5. `uv run pytest` — must not introduce new failures (note: the property suite is currently flaky from cross-test state pollution — a different test may fail per run but each passes in isolation)
+6. `npm run check:i18n` from `frontend/` — all 5 locale files must have identical key sets
+7. If you changed the DB schema, generate an Alembic migration (`alembic revision --autogenerate`) — never inline `ALTER`/`create_all` (see D-21)
+8. If you changed a design decision, update `docs/DECISIONS.md`
+9. If you changed the module structure, update `docs/ARCHITECTURE.md`
+
+CI mirrors the lint/test gates (`.github/workflows/test.yml`): the backend job runs
+`ruff check backend`, `bandit -rq backend --severity-level medium`, then pytest; the
+frontend job runs `tsc`, `eslint`, `npm run check:i18n`, and `npm audit`.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ With Qdrant you get:
 - **Scalar and binary quantisation** — reduce memory footprint for large archives
 - **Seamless migration** — switching backends migrates your existing embeddings without re-embedding anything
 
+### Library — Entity Grooming
+
+The Library page gives administrators tools to keep the entity space clean and the LLM context tight. It is gated behind the `can_groom` permission flag.
+
+- **Entity descriptions** — write or auto-generate LLM descriptions for every tag, correspondent, and document type. These descriptions are injected into the smart entity selection prompt so the LLM can distinguish between similarly-named entities and make better-informed picks from the shortlist.
+- **Deduplication** — detects near-duplicate entities using a combination of fuzzy name matching and embedding cosine similarity (both thresholds configurable). One click merges duplicates in Paperless-NGX, consolidating all document assignments automatically.
+- **Mismatch scan** — re-analyses already-approved documents against the current entity set and flags ones where the LLM would now suggest different tags, correspondents, or document types. Useful after bulk merges or entity renames to catch stale assignments.
+- **Scheduled scans** — mismatch scans run automatically on a configurable cron schedule; on-demand scan also available.
+
 ### Four LLM Providers, Zero Lock-in
 
 Run entirely on your own hardware, or use any major cloud provider:
@@ -163,6 +172,13 @@ Most tools give you one knob. Paperless IQ gives you a control panel:
 - **Field-level change history** — every metadata write is recorded with old value, new value, change source (manual vs. auto), and linked suggestion
 - **Configurable retention** — audit entries are automatically pruned after a configurable number of days (minimum 90)
 
+### Library — Entity Grooming
+- **Entity descriptions** — write or LLM-generate descriptions for every tag, correspondent, and document type; injected into smart entity selection prompts so the LLM distinguishes similarly-named entities
+- **Deduplication** — finds near-duplicate entity names via fuzzy string matching and embedding cosine similarity; merge candidates in Paperless-NGX with one click, reassigning all documents automatically
+- **Dismissals** — suppress individual dedup pairs that are intentionally distinct (dismissed pairs are not re-surfaced)
+- **Mismatch scan** — re-analyses approved documents against the current entity set and surfaces ones where the LLM would now suggest different metadata; runs on-demand or on a cron schedule
+- **Permission-gated** — Library page requires the `can_groom` permission flag; configured per user in Access Control
+
 ### Settings
 Settings are organised into eight tabs:
 
@@ -175,7 +191,7 @@ Settings are organised into eight tabs:
 | **Automation** | Enable/disable, auto-apply, poll interval, batch size, cron schedule, creation policies |
 | **Appearance** | Mantine primary colour, typography (font family and size), nav icons, UI language, colour scheme (light/dark/auto) |
 | **Memories** | Enable/disable long-term memory, list/edit/delete individual facts, clear all |
-| **Access Control** | Per-user permission flags, NG admin sync toggle, maintenance actions (reindex, reset tracking) |
+| **Access Control** | Per-user permission flags (including `can_groom`), NG admin sync toggle, maintenance actions (reindex, reset tracking) |
 
 ### UI & UX
 - **Responsive mobile layout** — sidebar slides in from the left as a drawer on small screens; a backdrop overlay and auto-close on navigation
@@ -307,6 +323,7 @@ Set `SECRET_KEY` explicitly only if you need to restore an encrypted database fr
 | `PIQ_LLM_PROVIDER` | `ollama` | `ollama` · `anthropic` · `openai` · `bedrock` |
 | `PIQ_LLM_MODEL` | `llama3` | Model name (provider-specific) |
 | `PIQ_LLM_CREDENTIALS` | — | API key (Anthropic/OpenAI) or JSON credentials (Bedrock) |
+| `PIQ_OPENAI_BASE_URL` | — | Custom base URL for OpenAI-compatible APIs (e.g. LM Studio, Open WebUI). Overrides the default OpenAI endpoint. |
 | `PIQ_OLLAMA_URL` | `http://localhost:11434` | Ollama server URL |
 | `PIQ_LLM_TIMEOUT_SECONDS` | `120` | LLM request timeout |
 | `PIQ_EMBED_PROVIDER` | `ollama` | Embedding provider: `ollama` · `openai` · `bedrock` |

--- a/backend/grooming.py
+++ b/backend/grooming.py
@@ -371,7 +371,6 @@ class GroomingService:
         )
         rows: dict[int, EntityDescriptionORM] = {r.entity_id: r for r in result.scalars().all()}
 
-        now = datetime.now(timezone.utc)
         for item in entities:
             eid = item["id"]
             name = item["name"]
@@ -483,7 +482,6 @@ class GroomingService:
         snippet_chars = getattr(self._config, "grooming_desc_snippet_chars", 300)
 
         # Fetch documents using this entity
-        etype_plural = {"tag": "tags", "correspondent": "correspondents", "document_type": "document_types"}[row.entity_type]
         filter_param = {"tag": "tags__id", "correspondent": "correspondent__id", "document_type": "document_type__id"}[row.entity_type]
         docs = await self._fetch_entity_docs(filter_param, row.entity_id, limit=sample_count)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -47,7 +47,7 @@ from backend.auth import (
     validate_paperless_credentials,
 )
 from backend.auth import _is_auth_required
-from backend.database import AsyncSessionLocal, DATABASE_URL, get_session
+from backend.database import AsyncSessionLocal, get_session
 from backend.keystore import get_machine_key
 from backend.inbox_monitor import InboxMonitor, Scheduler
 from backend.manual_analysis import ManualAnalysisService
@@ -56,8 +56,6 @@ from backend.ollama_queue import OllamaQueue, Priority
 from backend.orm_models import (
     ConversationSessionORM,
     DocumentTrackingORM,
-    EntityDescriptionORM,
-    GroomingDismissalORM,
     SuggestionORM,
     UserMemoryORM,
     UserPermissionsORM,

--- a/backend/orm_models.py
+++ b/backend/orm_models.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import JSON, Boolean, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "hypothesis>=6.155.7",
     "pytest>=9.1.1",
     "pytest-asyncio>=1.3.0",
+    "ruff>=0.15.16",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -2107,6 +2107,7 @@ dev = [
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -2140,6 +2141,7 @@ dev = [
     { name = "hypothesis", specifier = ">=6.155.7" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "ruff", specifier = ">=0.15.16" },
 ]
 
 [[package]]
@@ -3050,6 +3052,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
     { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
     { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/98/1295ad5a5aa9bc85bdcdfa5d82fe7b49c61af5657df4f227637ff9de0da6/ruff-0.15.18.tar.gz", hash = "sha256:2698a964c70e8bf402dcb99c8810472d270d141e7aa8c4e13599fd52033a2f33", size = 4761437, upload-time = "2026-06-18T18:25:39.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/d0/686e984941269621e2be72612d5c1e461f8f7b38415a2a7d7a81c8ae6715/ruff-0.15.18-py3-none-linux_armv6l.whl", hash = "sha256:8b6850172348c8381b8b3084c5915a4393c2373b9b54cd5b5e1ea15812bc10df", size = 10887308, upload-time = "2026-06-18T18:25:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/21/bc4123e3f5515ee99f8ce1eb93a14a0628fe4d1678663cd08f933ac16931/ruff-0.15.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3fccc153a85417dcd976883160cacce486997b0a0058dd18f54b8aaaac7d1ce2", size = 11281305, upload-time = "2026-06-18T18:25:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/93/4769464c25cf7ab2acb3c7dda9cad3d867eb41c59565b3e2a9d17249c90c/ruff-0.15.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:08d4c86a68f2c3ec2c9d56380a71fb4a4f65373055cbb8caabd645e9102f38d4", size = 10641215, upload-time = "2026-06-18T18:25:15.802Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/42/56926d17120db2c208d76bf60a1a019644dd9e91dc27f0f95c9caddb1366/ruff-0.15.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37e5108745c2c0705da916d7d4de533ddf547051ef45f62888c31bae73f66318", size = 10957224, upload-time = "2026-06-18T18:25:36.955Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4f/d43fab8d8189afde803103022d000a8ef9f230616d436d52a8b2b8d63b50/ruff-0.15.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56949a6ce8b3abde54c0bcb22cebfe57e8771cadc84b407ae8b8eaf67ebdcd43", size = 10699024, upload-time = "2026-06-18T18:25:05.707Z" },
+    { url = "https://files.pythonhosted.org/packages/63/42/1e3e4c68bd408b9768cf3e439acbe2c78245225faef253f7028a0cdb63e0/ruff-0.15.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01a754cd6a1b630d3f97e33eb452cf7a98040482318e870f8bc52a5a30e62657", size = 11491458, upload-time = "2026-06-18T18:25:20.275Z" },
+    { url = "https://files.pythonhosted.org/packages/20/77/47a3484bea8521e14a203d98c389c5c97846675e4f02734672da4a69b52a/ruff-0.15.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6ba7a07e03a44dbf10bb086ee06705b173625014ec99f73a7e6836a5e5590a0c", size = 12383752, upload-time = "2026-06-18T18:25:22.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/054159590787023d83b658a1a1819c4c8910114e7015069340b71c0961cb/ruff-0.15.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a2c40a41a4cadbcf5897b548ab29dfe248b20c540961c0247d98a3973c70403", size = 11577923, upload-time = "2026-06-18T18:25:10.702Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ff/d353d6b7bbd73cc0ec37f4463d7540e45e894338abdd9964eee0de332708/ruff-0.15.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f0480ce690cbb6c4db6e5d08f19fce98e10ba131a8b60c1bcdac42771e3ae2d", size = 11583925, upload-time = "2026-06-18T18:25:32.391Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4a/891f89b9c296ed3e5f3ece1a5629badc989d9a8fdaa30431aaf4774bc1c2/ruff-0.15.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2330215f1f393fa8733f55edce04fcf94c36a2c460fcde31f78cc84e4951e9b1", size = 11582834, upload-time = "2026-06-18T18:25:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a3/ed9e370154bf85de360b93c03026157f02d4943b2d01ff4945f4429f8e8a/ruff-0.15.18-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6aa6a3d979e48ae617578183674bf264fbe7d0114a796a26bd678d67963c7ff", size = 10927328, upload-time = "2026-06-18T18:25:34.676Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d1/5cf5909329fedb5d39d555ee818ba5cf4638e1a301b89785d34f2905bfcb/ruff-0.15.18-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a81beadbbff2c9c245561ae3f77b16709d87f35eec650d0501679239d3449b22", size = 10693187, upload-time = "2026-06-18T18:25:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/44/ff6c635cf2c4f4e7b618b6640da057376baa36014695487d88aed4794268/ruff-0.15.18-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2186d9e940ae332ab293623a75b5f4fe49565f449954d50a72a046683aa6b809", size = 11208721, upload-time = "2026-06-18T18:25:41.327Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d9/5baa2a30861adfb7022cf33c1e35b2fc18085b08c16f83eff4c7b99a5f48/ruff-0.15.18-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5c2abf140438032bc77b2284a6c9944ecd8a19e5f1c7b52b1b8e4a0a80d19a7a", size = 11678599, upload-time = "2026-06-18T18:25:13.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- **Fix 7 pre-existing `ruff` errors on `main`** — 5 unused imports (F401) auto-fixed in `main.py`/`orm_models.py`; 2 unused locals (F841, `now` and `etype_plural`) removed from `grooming.py`. Both removed assignments were side-effect-free.
- **Enforce lint in CI** (`.github/workflows/test.yml`) so these can't slip back onto `main` (the backend job previously ran only pip-audit + pytest):
  - backend job: `ruff check backend` + `bandit -rq backend --severity-level medium`
  - frontend job: `npm run lint` (eslint)
- **Document the full pre-push gate** in `CLAUDE.md` (ruff, bandit, eslint, tsc, i18n, pytest).

## Why

`ruff` errors reached `main` because CI never ran it. This makes the lint/security/typecheck tools a documented and enforced gate.

## Notes

- bandit is gated at **medium+** severity: the backend has 12 intentional Low `try/except/pass` (B110) that are accepted — gating at Low would fail CI on them.
- eslint currently emits 4 pre-existing `react-hooks/exhaustive-deps` warnings (0 errors); the step passes on warnings.

## Verification

- `ruff check backend` → clean
- `bandit -rq backend --severity-level medium` → exit 0
- `npm run lint` → 0 errors
- `uv run pytest` → 363 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)