### PR TITLE
fix(docker): constrain setuptools package discovery to backend/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build-and-push:
+    name: Build & push multi-arch image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU (cross-compilation for arm64)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Derive image tags from the pushed semver tag (e.g. v1.2.3):
+      #   ghcr.io/knows-cloud/paperless-iq:1.2.3
+      #   ghcr.io/knows-cloud/paperless-iq:1.2
+      #   ghcr.io/knows-cloud/paperless-iq:latest
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/knows-cloud/paperless-iq
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PIQ_EXTRAS=qdrant-hybrid,rerank-local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,12 +106,57 @@ frontend/src/
 
 ---
 
-## Before You Commit
+## Before You Commit / Push
+
+Run the lint, typecheck, and test gates locally **before pushing to GitHub** and
+fix anything they surface — do not rely on CI to catch it.
 
 1. `npx tsc --noEmit` from `frontend/` — zero errors required
-2. `ruff check backend` — zero errors required (config in `pyproject.toml`)
-3. `uv run pytest` — must not introduce new failures (note: the property suite is currently flaky from cross-test state pollution — a different test may fail per run but each passes in isolation)
-4. `npm run check:i18n` from `frontend/` — all 5 locale files must have identical key sets
-5. If you changed the DB schema, generate an Alembic migration (`alembic revision --autogenerate`) — never inline `ALTER`/`create_all` (see D-21)
-6. If you changed a design decision, update `docs/DECISIONS.md`
-7. If you changed the module structure, update `docs/ARCHITECTURE.md`
+2. `npm run lint` from `frontend/` — eslint (`eslint src`); zero errors required (warnings tolerated)
+3. `ruff check backend` — zero errors required (config in `pyproject.toml`); use `--fix` for autofixable lints
+4. `uv run bandit -rq backend --severity-level medium` — zero medium/high findings required
+5. `uv run pytest` — must not introduce new failures (note: the property suite is currently flaky from cross-test state pollution — a different test may fail per run but each passes in isolation)
+6. `npm run check:i18n` from `frontend/` — all 5 locale files must have identical key sets
+7. If you changed the DB schema, generate an Alembic migration (`alembic revision --autogenerate`) — never inline `ALTER`/`create_all` (see D-21)
+8. If you changed a design decision, update `docs/DECISIONS.md`
+9. If you changed the module structure, update `docs/ARCHITECTURE.md`
+
+---
+
+## Release Process
+
+Releases produce a versioned Docker image published to `ghcr.io/knows-cloud/paperless-iq`.
+The GitHub Actions workflow (`.github/workflows/release.yml`) fires automatically on a
+`vX.Y.Z` tag and pushes three image tags: the full semver, the minor-pinned alias, and `latest`.
+
+### Steps to cut a release
+
+1. **Bump the version** — update `version` in **both** files to the same value:
+   - `pyproject.toml` → `version = "X.Y.Z"`
+   - `frontend/package.json` → `"version": "X.Y.Z"`
+
+2. **Run all pre-commit gates** (see above) and fix anything they surface.
+
+3. **Commit and push to main:**
+   ```bash
+   git add pyproject.toml frontend/package.json
+   git commit -m "chore: bump version to X.Y.Z"
+   git push origin main
+   ```
+
+4. **Tag and push the tag** — this triggers the release workflow:
+   ```bash
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+5. **Verify** — the Actions tab on GitHub will show the `Release` workflow building
+   the multi-arch image. Once green, `ghcr.io/knows-cloud/paperless-iq:X.Y.Z`
+   and `:latest` are live. The version banner in the UI will show "Update available"
+   to anyone running an older image within an hour of the release.
+
+### Version source of truth
+
+`pyproject.toml` is the canonical version. `importlib.metadata.version("paperless-iq")`
+reads it at runtime via the installed package dist-info. `frontend/package.json` must
+be kept in sync manually — never bump one without the other.

--- a/README.md
+++ b/README.md
@@ -215,9 +215,7 @@ Add to your Paperless-NGX `docker-compose.yml`:
 
 ```yaml
   paperless-iq:
-    build:
-      context: /path/to/paperless-iq
-      dockerfile: docker/Dockerfile
+    image: ghcr.io/knows-cloud/paperless-iq:latest
     restart: unless-stopped
     depends_on:
       - webserver
@@ -244,10 +242,24 @@ volumes:
 Then:
 
 ```bash
-docker compose up -d --build paperless-iq
+docker compose up -d paperless-iq
 ```
 
 Access the UI at `http://localhost:8082`.
+
+### Keeping up to date
+
+The Paperless IQ sidebar shows your current version. When a newer release is available an "Update available" badge appears — click it to see the changelog.
+
+To update:
+
+```bash
+docker compose pull paperless-iq && docker compose up -d paperless-iq
+```
+
+To pin to a specific version instead of `latest`, use an image tag like
+`ghcr.io/knows-cloud/paperless-iq:1.0` (minor-pinned, gets patch updates) or
+`ghcr.io/knows-cloud/paperless-iq:1.0.0` (exact).
 
 ### Using Qdrant
 
@@ -463,7 +475,21 @@ uv run uvicorn backend.main:app --reload
 uv run alembic upgrade head
 ```
 
-### Rebuilding the Docker image after code changes
+### Building from source
+
+If you want to run from a local clone instead of the pre-built image, replace
+`image:` with a `build:` block in your compose file:
+
+```yaml
+  paperless-iq:
+    build:
+      context: /path/to/paperless-iq
+      dockerfile: docker/Dockerfile
+      args:
+        PIQ_EXTRAS: qdrant-hybrid,rerank-local
+```
+
+Then rebuild after code changes:
 
 ```bash
 docker compose build paperless-iq && docker compose up -d paperless-iq

--- a/backend/grooming.py
+++ b/backend/grooming.py
@@ -371,7 +371,6 @@ class GroomingService:
         )
         rows: dict[int, EntityDescriptionORM] = {r.entity_id: r for r in result.scalars().all()}
 
-        now = datetime.now(timezone.utc)
         for item in entities:
             eid = item["id"]
             name = item["name"]
@@ -483,7 +482,6 @@ class GroomingService:
         snippet_chars = getattr(self._config, "grooming_desc_snippet_chars", 300)
 
         # Fetch documents using this entity
-        etype_plural = {"tag": "tags", "correspondent": "correspondents", "document_type": "document_types"}[row.entity_type]
         filter_param = {"tag": "tags__id", "correspondent": "correspondent__id", "document_type": "document_type__id"}[row.entity_type]
         docs = await self._fetch_entity_docs(filter_param, row.entity_id, limit=sample_count)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.metadata
 import json as _json
 import logging
 import os
 import re as _re
+import time
 
 # Configure application logging so INFO messages from all backend modules appear
 # in the container log alongside uvicorn's own access log.
@@ -32,6 +34,17 @@ from sqlalchemy import delete as sa_delete, func, select, update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.analyzer import PaperlessNGXClient
+
+
+def _get_app_version() -> str:
+    """Read the package version from installed metadata or pyproject.toml fallback."""
+    try:
+        return importlib.metadata.version("paperless-iq")
+    except importlib.metadata.PackageNotFoundError:
+        import tomllib
+        pyproject = Path(__file__).parent.parent / "pyproject.toml"
+        with open(pyproject, "rb") as f:
+            return tomllib.load(f)["project"]["version"]
 from backend.models import VisionAnalysisResult
 from backend.pdf_utils import get_page_count
 from backend.approval_queue import ApprovalQueueService
@@ -47,7 +60,7 @@ from backend.auth import (
     validate_paperless_credentials,
 )
 from backend.auth import _is_auth_required
-from backend.database import AsyncSessionLocal, DATABASE_URL, get_session
+from backend.database import AsyncSessionLocal, get_session
 from backend.keystore import get_machine_key
 from backend.inbox_monitor import InboxMonitor, Scheduler
 from backend.manual_analysis import ManualAnalysisService
@@ -56,8 +69,6 @@ from backend.ollama_queue import OllamaQueue, Priority
 from backend.orm_models import (
     ConversationSessionORM,
     DocumentTrackingORM,
-    EntityDescriptionORM,
-    GroomingDismissalORM,
     SuggestionORM,
     UserMemoryORM,
     UserPermissionsORM,
@@ -1204,7 +1215,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(
     title="Paperless IQ",
     description="AI-powered metadata suggestions for Paperless NGX",
-    version="0.1.0",
+    version=_get_app_version(),
     lifespan=lifespan,
 )
 
@@ -3157,6 +3168,46 @@ async def translate_prompt(body: TranslatePromptBody, request: Request) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Version endpoint
+# ---------------------------------------------------------------------------
+
+_GITHUB_RELEASES_URL = "https://api.github.com/repos/knows-cloud/paperless-iq/releases/latest"
+_GITHUB_RELEASES_PAGE = "https://github.com/knows-cloud/paperless-iq/releases"
+_version_cache: dict[str, Any] = {}  # keys: latest_version, fetched_at
+
+
+async def _fetch_latest_release() -> str | None:
+    """Return the latest GitHub release tag, cached for 1 hour. None on any error."""
+    now = time.monotonic()
+    if _version_cache.get("latest_version") and now - _version_cache.get("fetched_at", 0) < 3600:
+        return _version_cache["latest_version"]
+    try:
+        async with httpx.AsyncClient(timeout=5, headers={"User-Agent": "paperless-iq"}) as client:
+            resp = await client.get(_GITHUB_RELEASES_URL)
+        if resp.status_code == 200:
+            tag = resp.json().get("tag_name", "")
+            latest = tag.lstrip("v")
+            _version_cache["latest_version"] = latest
+            _version_cache["fetched_at"] = now
+            return latest
+    except Exception:
+        pass
+    return None
+
+
+@app.get("/api/version", tags=["system"])
+async def get_version() -> dict:
+    """Return the running app version and whether a newer release is available."""
+    current = _get_app_version()
+    latest = await _fetch_latest_release()
+    update_available = bool(latest and latest != current)
+    result: dict[str, Any] = {"version": current, "update_available": update_available}
+    if update_available:
+        result["latest_version"] = latest
+        result["releases_url"] = _GITHUB_RELEASES_PAGE
+    return result
+
+
 # Status & Reindex endpoints
 # ---------------------------------------------------------------------------
 

--- a/backend/orm_models.py
+++ b/backend/orm_models.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import JSON, Boolean, DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.database import Base

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,8 @@
 # Stage 1: Build frontend
 FROM node:20-alpine AS frontend-build
 WORKDIR /app/frontend
-COPY frontend/package.json frontend/package-lock.json* ./
-RUN npm install
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
 COPY frontend/ ./
 RUN npm run build
 
@@ -17,49 +17,42 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential libgomp1 && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies from pyproject.toml (single source of truth) via uv.
-# Hybrid search (fastembed) is included by default. Add more optional extras with
-# the PIQ_EXTRAS build arg (comma-separated), e.g. to also bundle the local torch
-# reranker:  --build-arg PIQ_EXTRAS=qdrant-hybrid,rerank-local
-# Set PIQ_EXTRAS= (empty) for the leanest image (no hybrid).
 RUN pip install --no-cache-dir uv
+
+# Install Python dependencies (layer cached until pyproject.toml changes).
+# Optional extras are controlled by the PIQ_EXTRAS build arg (comma-separated):
+#   qdrant-hybrid  — fastembed sparse encoder for Qdrant hybrid search
+#   rerank-local   — sentence-transformers + CPU torch cross-encoder reranker
+# docker-compose.yml defaults to both; set PIQ_EXTRAS= for the leanest image.
 COPY pyproject.toml ./
 ARG PIQ_EXTRAS="qdrant-hybrid"
+
 # When the local reranker is bundled, pre-install the CPU-only torch wheel so
-# sentence-transformers reuses it instead of pulling the default ~3 GB CUDA build
-# (this container runs CPU-only — no GPU is passed in). Must run BEFORE the main
-# install so the CPU build is already-satisfied and wins resolution.
+# sentence-transformers reuses it instead of pulling the default ~3 GB CUDA
+# build. Must run BEFORE the main install so the CPU build wins resolution.
 RUN if echo ",$PIQ_EXTRAS," | grep -q ',rerank-local,'; then \
         uv pip install --system --no-cache \
             --index-url https://download.pytorch.org/whl/cpu torch; \
     fi
+
 RUN uv pip install --system --no-cache -r pyproject.toml \
     $(for e in $(echo "$PIQ_EXTRAS" | tr ',' ' '); do printf -- '--extra %s ' "$e"; done)
 
-# Copy backend source
+# Copy source and register the package so importlib.metadata.version() works.
 COPY backend/ ./backend/
-COPY main.py ./
-COPY alembic.ini ./
-
-# Copy Alembic config
-COPY backend/alembic/ ./backend/alembic/
-
-# Copy built frontend
+COPY main.py alembic.ini ./
 COPY --from=frontend-build /app/frontend/dist ./frontend/dist
+RUN uv pip install --system --no-cache --no-deps .
 
-# Create data directory
 RUN mkdir -p /data
 
-# Environment defaults
 ENV DATABASE_URL=sqlite+aiosqlite:////data/paperless_iq.db
 ENV PYTHONUNBUFFERED=1
+ENV HF_HOME=/data/hf-cache
 
 EXPOSE 8080
 VOLUME ["/data"]
 
-# Schema migrations run at app startup in the FastAPI lifespan — see
-# backend/db_migrate.py, which self-heals pre-Alembic and stale-revision
-# databases and logs visibly. No standalone "alembic upgrade head" here — it
-# lacks that self-heal and would fail loudly on existing databases. Exec form so
-# uvicorn is PID 1 (clean SIGTERM).
+# Schema migrations run at app startup (backend/db_migrate.py self-heals
+# pre-Alembic and stale-revision DBs). Exec form so uvicorn is PID 1.
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080", "--log-level", "info"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Paperless IQ — single-container build
 
 # Stage 1: Build frontend
-FROM node:20-alpine AS frontend-build
+FROM node:24-alpine AS frontend-build
 WORKDIR /app/frontend
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paperless-iq-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import LoginPage from "./pages/LoginPage";
 import LibraryPage from "./pages/LibraryPage";
 import { api, clearStoredToken } from "./api";
 import type { UserPermissions } from "./api";
+import VersionBadge from "./components/VersionBadge";
 
 type Page = "manual" | "queue" | "discovery" | "processing" | "audit" | "settings" | "library";
 
@@ -225,6 +226,11 @@ export default function App() {
             </Button>
           </Box>
         )}
+
+        {/* Version badge */}
+        <Box px="md" pb="sm" pt={authRequired && authUser ? 0 : "xs"}>
+          <VersionBadge />
+        </Box>
       </AppShell.Navbar>
 
       <AppShell.Main>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -97,6 +97,13 @@ export interface ConnectionTestResult {
   version?: string;
 }
 
+export interface VersionInfo {
+  version: string;
+  update_available: boolean;
+  latest_version?: string;
+  releases_url?: string;
+}
+
 export interface AuthMeResponse {
   user: string | null;
   auth_required: boolean;
@@ -323,6 +330,7 @@ export const api = {
   getStoragePaths: () => request<PaperlessEntity[]>("/paperless/storage_paths"),
   getTheme: () => request<{ primary_color: string; sidebar_from: string; sidebar_to: string; font: string; font_size: string; text_color: string; bg_color: string; card_color: string; card_alt_hex: string; card_alt_opacity: number; nav_icons: Record<string, string>; ui_language: string; chip_color: string }>("/theme"),
   getStatus: () => request<{ llm_online: boolean; embed_online: boolean; queue_pending: number; queue_processing: number; embedded_chunks: number; total_documents: number; processing: Record<string, unknown>; paperless_url: string; paperless_public_url: string }>("/status"),
+  getVersion: () => request<VersionInfo>("/version"),
   getDocumentPreview: (id: number) => requestBlob(`/documents/${id}/preview`),
   triggerReindex: () => request<{ detail: string }>("/reindex", { method: "POST" }),
   migrateVectorStore: () => request<{ migrated: number; memories_migrated: number; needs_reindex: boolean; detail: string }>("/vector/migrate", { method: "POST" }),

--- a/frontend/src/components/VersionBadge.tsx
+++ b/frontend/src/components/VersionBadge.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { Anchor, Badge, Group, Text, Tooltip } from "@mantine/core";
+import { IconArrowUpCircle } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+import { api } from "../api";
+import type { VersionInfo } from "../api";
+
+export default function VersionBadge() {
+  const { t } = useTranslation();
+  const [info, setInfo] = useState<VersionInfo | null>(null);
+
+  useEffect(() => {
+    api.getVersion().then(setInfo).catch(() => {});
+  }, []);
+
+  if (!info) return null;
+
+  return (
+    <Group gap={6} wrap="nowrap" align="center">
+      <Text size="xs" c="dimmed">v{info.version}</Text>
+      {info.update_available && info.releases_url && (
+        <Tooltip label={t("version.updateTooltip", { latest: info.latest_version })} withArrow>
+          <Anchor href={info.releases_url} target="_blank" rel="noopener noreferrer" style={{ lineHeight: 1 }}>
+            <Badge
+              size="xs"
+              variant="light"
+              color="teal"
+              leftSection={<IconArrowUpCircle size={10} />}
+              styles={{ root: { cursor: "pointer" } }}
+            >
+              {t("version.updateAvailable")}
+            </Badge>
+          </Anchor>
+        </Tooltip>
+      )}
+    </Group>
+  );
+}

--- a/frontend/src/locales/de/translation.json
+++ b/frontend/src/locales/de/translation.json
@@ -582,5 +582,7 @@
   "grooming.settings.scan.cron.label": "Scan-Cron",
   "grooming.settings.scan.cron.tip": "Cron-Ausdruck für automatische Scan-Läufe. Leer lassen zum Deaktivieren.",
   "grooming.settings.scan.resuggestDays.label": "Erneut vorschlagen nach (Tage)",
-  "grooming.settings.scan.resuggestDays.tip": "Tage nach denen ein verworfener Vorschlag erneut generiert werden kann. 0 = nie."
+  "grooming.settings.scan.resuggestDays.tip": "Tage nach denen ein verworfener Vorschlag erneut generiert werden kann. 0 = nie.",
+  "version.updateAvailable": "Update verfügbar",
+  "version.updateTooltip": "v{{latest}} ist verfügbar – Versionshinweise ansehen"
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -582,5 +582,7 @@
   "grooming.settings.scan.cron.label": "Scan cron",
   "grooming.settings.scan.cron.tip": "Cron expression for automated scan runs (e.g. '0 2 * * *' for 2 AM daily). Leave blank to disable.",
   "grooming.settings.scan.resuggestDays.label": "Re-suggest after (days)",
-  "grooming.settings.scan.resuggestDays.tip": "Days after which a dismissed suggestion may be re-generated. 0 = never re-suggest."
+  "grooming.settings.scan.resuggestDays.tip": "Days after which a dismissed suggestion may be re-generated. 0 = never re-suggest.",
+  "version.updateAvailable": "Update available",
+  "version.updateTooltip": "v{{latest}} is available — see release notes"
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -582,5 +582,7 @@
   "grooming.settings.scan.cron.label": "Cron de escaneo",
   "grooming.settings.scan.cron.tip": "Expresión cron para ejecuciones automáticas de escaneo. Dejar vacío para desactivar.",
   "grooming.settings.scan.resuggestDays.label": "Re-sugerir después de (días)",
-  "grooming.settings.scan.resuggestDays.tip": "Días tras los cuales puede regenerarse una sugerencia descartada. 0 = nunca."
+  "grooming.settings.scan.resuggestDays.tip": "Días tras los cuales puede regenerarse una sugerencia descartada. 0 = nunca.",
+  "version.updateAvailable": "Actualización disponible",
+  "version.updateTooltip": "v{{latest}} está disponible – ver notas de la versión"
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -582,5 +582,7 @@
   "grooming.settings.scan.cron.label": "Cron de scan",
   "grooming.settings.scan.cron.tip": "Expression cron pour les exécutions automatiques de scan. Laisser vide pour désactiver.",
   "grooming.settings.scan.resuggestDays.label": "Re-suggérer après (jours)",
-  "grooming.settings.scan.resuggestDays.tip": "Jours après lesquels une suggestion rejetée peut être re-générée. 0 = jamais."
+  "grooming.settings.scan.resuggestDays.tip": "Jours après lesquels une suggestion rejetée peut être re-générée. 0 = jamais.",
+  "version.updateAvailable": "Mise à jour disponible",
+  "version.updateTooltip": "v{{latest}} est disponible – voir les notes de version"
 }

--- a/frontend/src/locales/it/translation.json
+++ b/frontend/src/locales/it/translation.json
@@ -582,5 +582,7 @@
   "grooming.settings.scan.cron.label": "Cron scansione",
   "grooming.settings.scan.cron.tip": "Espressione cron per esecuzioni automatiche di scansione. Lasciare vuoto per disabilitare.",
   "grooming.settings.scan.resuggestDays.label": "Ri-suggerisci dopo (giorni)",
-  "grooming.settings.scan.resuggestDays.tip": "Giorni dopo i quali un suggerimento ignorato può essere rigenerato. 0 = mai."
+  "grooming.settings.scan.resuggestDays.tip": "Giorni dopo i quali un suggerimento ignorato può essere rigenerato. 0 = mai.",
+  "version.updateAvailable": "Aggiornamento disponibile",
+  "version.updateTooltip": "v{{latest}} è disponibile – vedi le note di rilascio"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paperless-iq"
-version = "0.1.0"
+version = "1.0.0"
 description = "AI-powered metadata suggestions for Paperless NGX"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ markers = [
 ]
 addopts = "-m 'not live'"
 
+[tool.setuptools.packages.find]
+include = ["backend*"]
+
 [tool.ruff]
 target-version = "py312"
 # Alembic-generated files have their own conventions; don't lint them.


### PR DESCRIPTION
Setuptools auto-discovery finds both `backend/` and `frontend/` and refuses to build (`Multiple top-level packages discovered`). Adds `[tool.setuptools.packages.find]` with `include = ["backend*"]` so only the Python package is registered and `importlib.metadata.version("paperless-iq")` resolves correctly in the container.

Discovered during the 1.0.0 release build — this fix was what unblocked it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018ZejtLjEMPkvbJ26aWoTvw