### PR TITLE
fix(docker): constrain setuptools package discovery to backend/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ markers = [
 ]
 addopts = "-m 'not live'"
 
+[tool.setuptools.packages.find]
+include = ["backend*"]
+
 [tool.ruff]
 target-version = "py312"
 # Alembic-generated files have their own conventions; don't lint them.


### PR DESCRIPTION
Setuptools auto-discovery finds both `backend/` and `frontend/` and refuses to build (`Multiple top-level packages discovered`). Adds `[tool.setuptools.packages.find]` with `include = ["backend*"]` so only the Python package is registered and `importlib.metadata.version("paperless-iq")` resolves correctly in the container.

Discovered during the 1.0.0 release build — this fix was what unblocked it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_018ZejtLjEMPkvbJ26aWoTvw