### PR TITLE
fix(frontend): stale description editor + enforce the lint gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ job historically ran only pip-audit + pytest, so a green CI does **not** prove t
 backend is ruff-clean; always run ruff yourself.
 
 1. `npx tsc --noEmit` from `frontend/` — zero errors required
-2. `npm run lint` from `frontend/` — eslint (`eslint src`); catches React-hooks/code-quality issues `tsc` misses. Zero errors required (warnings are tolerated but should trend down)
+2. `npm run lint` from `frontend/` — eslint (`eslint src --max-warnings=0`); catches React-hooks issues `tsc` structurally cannot (stale closures, missing effect deps). **Zero warnings required** — the gate fails on any warning. `exhaustive-deps` is a `warn`, and a bare `eslint src` exits 0 on warnings, so before `--max-warnings=0` the gate was advisory and a real stale-value bug sat unfixed for weeks. If a warning is a genuine false positive, suppress it with a targeted `// eslint-disable-next-line` **plus a comment saying why** — don't relax the gate
 3. `ruff check backend` — zero errors required (config in `pyproject.toml`); use `--fix` for autofixable lints
 4. `uv run bandit -rq backend --severity-level medium` — security linter; finds smells ruff's default rules don't (hardcoded secrets, `shell=True`, weak crypto). Zero medium/high findings required. (Plain `bandit -rq backend` also flags 12 intentional Low `try/except/pass` (B110) — those are accepted, hence the `medium` gate.)
 5. `uv run pytest` — must not introduce new failures (note: the property suite is currently flaky from cross-test state pollution — a different test may fail per run but each passes in isolation)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint src",
+    "lint": "eslint src --max-warnings=0",
     "knip": "knip",
     "check:i18n": "node scripts/check-i18n.mjs"
   },

--- a/frontend/src/pages/LibraryPage.tsx
+++ b/frontend/src/pages/LibraryPage.tsx
@@ -45,11 +45,24 @@ function DescriptionsTab({ entityType }: { entityType: EntityType }) {
       .then(setEntities)
       .catch(err => setMsg(t("grooming.error", { msg: err.message })))
       .finally(() => setLoading(false));
+    // `t` is deliberately omitted: it changes identity on language switch, and
+    // re-running this effect would clear the selection and any unsaved edit
+    // just because the user changed language. `t` is only read in the error
+    // path, where a stale translator is harmless.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entityType]);
 
+  // null = nothing selected; "" = selected but no description yet.
+  const selectedDescription = selected ? (selected.description ?? "") : null;
+
+  // Depends on the description *string*, not `selected`: generation finishing
+  // swaps `entities` without changing `selectedId`, which previously left the
+  // editor showing pre-generation text. Keying on the string also means an
+  // unrelated refresh of `entities` won't clobber an unsaved edit.
   useEffect(() => {
-    if (selected) setDescText(selected.description ?? "");
-  }, [selectedId]);
+    if (selectedDescription === null) return;
+    setDescText(selectedDescription);
+  }, [selectedId, selectedDescription]);
 
   // Poll generation status while running
   useEffect(() => {
@@ -68,7 +81,7 @@ function DescriptionsTab({ entityType }: { entityType: EntityType }) {
       }, 2000);
     }
     return () => { if (pollRef.current) clearInterval(pollRef.current); };
-  }, [genStatus?.running]);
+  }, [genStatus?.running, entityType]);
 
   async function handleSave() {
     if (!selected) return;

--- a/frontend/src/pages/QueuePage.tsx
+++ b/frontend/src/pages/QueuePage.tsx
@@ -125,7 +125,13 @@ export default function QueuePage() {
     return () => { Object.values(urls).forEach(u => URL.revokeObjectURL(u)); };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const items = (data?.items ?? []) as Array<Record<string, unknown>>;
+  // Memoised so the `?? []` fallback doesn't mint a fresh array identity on
+  // every render, which would defeat the `groups` memo below while data is
+  // still loading.
+  const items = useMemo(
+    () => (data?.items ?? []) as Array<Record<string, unknown>>,
+    [data?.items],
+  );
 
   // Group pending suggestions by document — one card per document, a tab per
   // suggestion. Within a group: chronological (oldest → newest, newest selected


### PR DESCRIPTION
Started as the TypeScript 7 upgrade (#94). That turned out to be blocked upstream — see below — but investigating it surfaced a real, user-visible bug that eslint had been reporting for weeks and CI had been ignoring. This PR fixes that instead.

## The bug

`LibraryPage`'s description editor synced on `[selectedId]` but read `selected`, which derives from **both** `entities` and `selectedId`:

```js
const selected = entities.find(e => e.entity_id === selectedId) ?? null;

useEffect(() => {
  if (selected) setDescText(selected.description ?? "");
}, [selectedId]);                                  // ← missing `selected`
```

When description generation finishes, the poll effect right below calls `setEntities(updated)` **without touching `selectedId`** — so this effect never re-ran and the textarea kept showing the pre-generation text.

**Repro:** select an entity → Generate → wait for it to finish. The generated description is in `entities` but not on screen until you click away and back. That's the grooming feature's main flow.

**Fix:** key on the description *string* rather than the `selected` object, so it re-syncs when the description actually changes, while an unrelated refresh of `entities` still won't clobber an unsaved edit. `null` vs `""` is kept distinct so "nothing selected" doesn't clear the editor (the naive fix regresses this).

## Also fixed

- **Stale `entityType` in the poll effect** — switching entity type mid-generation reloaded the *previous* type's entities.
- **`QueuePage` `items`** — `data?.items ?? []` minted a fresh array identity every render, defeating the `groups` memo while data was loading. Now memoised.
- **The `t` omission** on the fetch effect is a genuine false positive: including it would reset the selection and any unsaved edit on a language switch. Now an explicit `eslint-disable-next-line` **with a stated reason**, rather than an ignored warning.

## Why this sat for weeks: the gate never bit

`exhaustive-deps` is a `warn`, and `eslint src` **exits 0 on warnings-only**. CI ran `npm run lint`, got exit 0, went green — every time. The flagged code is 4–5 weeks old; the lint gate only entered CI 3 weeks ago (#51), so these predate it and were never blocking. eslint wasn't broken or asleep: it printed the bug and exited 0, exactly as configured.

Gate is now `eslint src --max-warnings=0`. Verified rather than assumed — a deliberately introduced `exhaustive-deps` warning:

| Gate | Exit |
|---|---|
| `eslint src --max-warnings=0` (new) | **1** — blocks |
| `eslint src` (old) | **0** — ships |

CI runs `npm run lint`, so it inherits the flag with no workflow change. `CLAUDE.md` updated: it previously said "warnings are tolerated but should trend down", which is what licensed this.

## On TypeScript 7 (#94) — blocked upstream, not by us

Worth recording, since #94 will keep failing:

- **Our code is already TS 7-clean.** `npx tsc --noEmit` on 7.0.2 exits 0. Zero source changes needed.
- **typescript-eslint cannot load under TS 7.** TS 7 is the Go-based native port — it ships platform binaries and no longer exposes the JS compiler API. `@typescript-eslint/typescript-estree` reads `ts.Extension.Cjs` at *module load*, gets `undefined`, and crashes. Not config-dependent (this repo doesn't even use type-aware rules — typescript-eslint is only the parser).
- **No published version supports it.** `typescript-eslint@8.64.0` (latest) and canary `8.64.1-alpha.3` both declare `typescript@">=4.8.4 <6.1.0"`. That's why #94 dies at `npm ci` on ERESOLVE, before ever reaching a compile error.

So #94 should be held until typescript-eslint ships TS 7 support. Since our code already typechecks clean under 7, waiting costs nothing but the wait — the only thing TS 7 buys here is compile speed.

## Testing

There's no frontend test infrastructure (no vitest/testing-library), so this is verified via `tsc`, `eslint`, `vite build`, and the gate canary above — not a unit test. The `LibraryPage` fix is reasoned from the data flow rather than driven end-to-end; worth a manual pass through Grooming → Descriptions → Generate to confirm the editor now updates in place.

All gates green: `lint --max-warnings=0`, `tsc`, `build`, `check:i18n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PV1cy9kCP4f2rcajFuetYV