### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paperless-iq-frontend",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paperless-iq"
-version = "1.0.0"
+version = "1.1.0"
 description = "AI-powered metadata suggestions for Paperless NGX"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Version bump for the 1.1.0 minor release. Both sources of truth moved together (`pyproject.toml` is canonical; `frontend/package.json` is kept in sync manually).

## What's in 1.1.0 since v1.0.0

**Fixes**
- **#97** — entity creation gated per entity type. `allow_new` on tags no longer also creates correspondents, document types and storage paths. Adds `storage_path_creation_policy`. `bulk_approve` now creates entities like single-approve did (it silently dropped them). Auto-apply audits as `change_source=automation` rather than `human`. Documented as D-25.
- **#98** — grooming description editor kept showing pre-generation text after generation completed. Lint gate now enforces `--max-warnings=0`.

**Dependencies** — fastapi, uvicorn, anthropic, boto3, pypdfium2, mantine, i18next, react-i18next, typescript-eslint, ruff, hypothesis.

## Gates

All green locally on this bump: `ruff check backend`, `bandit --severity-level medium`, `pytest` (367 passed), `tsc`, `eslint --max-warnings=0`, `check:i18n`, `vite build`.

Tagging `v1.1.0` once this merges, which fires the release workflow and publishes `ghcr.io/knows-cloud/paperless-iq:1.1.0`, `:1.1`, and `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PV1cy9kCP4f2rcajFuetYV