### PR TITLE
ci(release): create a GitHub Release for every tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build & push multi-arch image
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write   # create the GitHub Release for the tag
       packages: write
 
     steps:
@@ -56,3 +56,25 @@ jobs:
             PIQ_EXTRAS=qdrant-hybrid,rerank-local
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Every release gets an entry on the Releases page, not just images.
+      # Runs after the push so a failed build never announces a release that
+      # has no image behind it. Notes are auto-generated from the PRs merged
+      # since the previous release — edit them afterwards to add upgrade notes
+      # or behaviour changes (see docs: Release Process).
+      # Re-running this workflow on an existing tag is a no-op rather than a
+      # failure, so a re-run after a transient build error stays green.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — leaving it untouched."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag \
+            --latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,12 @@ backend is ruff-clean; always run ruff yourself.
 
 ## Release Process
 
-Releases produce a versioned Docker image published to `ghcr.io/knows-cloud/paperless-iq`.
-The GitHub Actions workflow (`.github/workflows/release.yml`) fires automatically on a
-`vX.Y.Z` tag and pushes three image tags: the full semver, the minor-pinned alias, and `latest`.
+Releases produce a versioned Docker image published to `ghcr.io/knows-cloud/paperless-iq`
+**and** an entry on the GitHub Releases page. The GitHub Actions workflow
+(`.github/workflows/release.yml`) fires automatically on a `vX.Y.Z` tag: it pushes three
+image tags (full semver, minor-pinned alias, `latest`) and then creates the GitHub Release.
+Both come from the same tag — there is no such thing as a release with images but no
+Releases entry.
 
 ### Steps to cut a release
 
@@ -139,23 +142,33 @@ The GitHub Actions workflow (`.github/workflows/release.yml`) fires automaticall
 
 2. **Run all pre-commit gates** (see above) and fix anything they surface.
 
-3. **Commit and push to main:**
+3. **Get the bump onto main** — via PR (preferred; CI runs on it) or directly:
    ```bash
    git add pyproject.toml frontend/package.json
    git commit -m "chore: bump version to X.Y.Z"
-   git push origin main
    ```
 
-4. **Tag and push the tag** — this triggers the release workflow:
+4. **Tag the commit *on main*, then push the tag** — this triggers the release workflow:
    ```bash
-   git tag vX.Y.Z
+   git fetch origin
+   git tag -a vX.Y.Z origin/main -m "vX.Y.Z"   # NOT a PR-branch commit
    git push origin vX.Y.Z
    ```
+   **Tag `origin/main`, never a pre-squash branch commit.** Squash-merging rewrites the
+   commit, so a tag cut from the PR branch points at a SHA that isn't in main's history —
+   it dangles, and every `git log <tag>..HEAD` and auto-generated changelog against it is
+   wrong. `v1.0.0` was tagged this way (`a2076f9`, not on main); check with
+   `git merge-base --is-ancestor vX.Y.Z^{commit} origin/main` before pushing.
 
-5. **Verify** — the Actions tab on GitHub will show the `Release` workflow building
-   the multi-arch image. Once green, `ghcr.io/knows-cloud/paperless-iq:X.Y.Z`
-   and `:latest` are live. The version banner in the UI will show "Update available"
-   to anyone running an older image within an hour of the release.
+5. **Verify and curate** — the Actions tab shows the `Release` workflow building the
+   multi-arch image, then creating the Release. Once green, `:X.Y.Z` and `:latest` are
+   live and the Releases page has an entry. The version banner shows "Update available"
+   to anyone on an older image within an hour.
+
+   The workflow's notes are **auto-generated from merged PRs** — a bare list. For any
+   release with behaviour changes, edit the notes afterwards
+   (`gh release edit vX.Y.Z --notes-file notes.md`) to lead with what upgraders must know.
+   `v1.1.0` is the worked example of the shape to aim for.
 
 ### Version source of truth
 


### PR DESCRIPTION
Makes a Releases-page entry part of every release, not a manual afterthought.

## Change

`release.yml` gains a final `Create GitHub Release` step and `contents: write`.

- **Runs after the image push**, so a failed build never announces a release with no image behind it.
- **Notes auto-generated** from PRs merged since the previous release (`--generate-notes`).
- **Idempotent** — re-running the workflow on an existing tag logs and exits 0 rather than failing. A re-run after a transient build error stays green and won't clobber hand-curated notes.
- Tag name passed via `env:` rather than `${{ }}` interpolation inside `run:` (workflow-injection safe pattern; the tag is already constrained by the semver filter, but the safe form costs nothing).

## v1.1.0

Created retroactively with curated notes, since it predates this change: https://github.com/knows-cloud/paperless-iq/releases/tag/v1.1.0

That's also the worked example the docs point at for the shape to aim for — auto-generated notes are a bare PR list, which is fine for a dependency-only release but not for one with behaviour changes.

## Heads-up: the `v1.0.0` tag is misplaced

Found while assembling the v1.1.0 notes. `v1.0.0` points at `a2076f9`, which is **not an ancestor of main** — it's the pre-squash commit of PR #71. Main has the same change as the squashed `92a6cd2`. The tag was cut from the PR branch instead of main.

Consequences: `git log v1.0.0..v1.1.0` reports 30 commits including "bump version to 1.0.0" itself; the true diff (`92a6cd2..v1.1.0`) is 16. Any auto-generated changelog diffed against `v1.0.0` would be wrong.

**Not fixed here** — moving a published tag rewrites what people have already pulled, so that's your call. From v1.1.0 onward the problem is self-healing: v1.1.0 is correctly on main and `--generate-notes` diffs against the previous *Release*, which now exists.

The docs now carry the rule and the verification command:

```bash
git merge-base --is-ancestor vX.Y.Z^{commit} origin/main
```

## Verification

Workflow YAML parsed and asserted: `contents: write` present, release step is last, tag passed via `env`, no `${{ }}` inside `run`. `ruff check backend` and `check:i18n` green (change is workflow + docs only).

The step itself can't be proven until the next tag fires it — the idempotency guard means a re-run of an earlier tag is a safe way to smoke-test it if you want that before v1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PV1cy9kCP4f2rcajFuetYV