### PR TITLE
fix(reembed): drop stale rows for deleted docs; quiet transient NGX outages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -254,8 +254,14 @@ async def _automation_loop(app: FastAPI, poll_interval: int) -> None:
                     logger.info("Inbox poll submitted %d documents.", len(submitted))
         except asyncio.CancelledError:
             raise
-        except Exception:
-            logger.exception("Inbox polling loop error")
+        except Exception as exc:
+            if _is_transient_paperless_error(exc):
+                logger.warning(
+                    "Inbox polling: Paperless unavailable (%s); will retry next poll.",
+                    type(exc).__name__,
+                )
+            else:
+                logger.exception("Inbox polling loop error")
 
         await asyncio.sleep(poll_interval)
 
@@ -594,8 +600,14 @@ async def _background_index(
         logger.info("Background indexing complete: %d new documents indexed, %d inbox-skipped, %d already indexed.", indexed, inbox_skipped, already_done)
         if queue:
             queue.set_embedding_progress(total_to_index, total_to_index)  # mark complete
-    except Exception:
-        logger.warning("Background indexing failed.", exc_info=True)
+    except Exception as exc:
+        if _is_transient_paperless_error(exc):
+            logger.warning(
+                "Background indexing: Paperless unavailable (%s); will retry later.",
+                type(exc).__name__,
+            )
+        else:
+            logger.warning("Background indexing failed.", exc_info=True)
 
 
 async def _embed_health_monitor(app: FastAPI, queue: OllamaQueue) -> None:
@@ -789,6 +801,49 @@ async def _daily_reembed_loop(app: FastAPI) -> None:
             logger.warning("Daily re-embed loop error", exc_info=True)
 
 
+def _is_transient_paperless_error(exc: BaseException) -> bool:
+    """True when *exc* reflects a temporary Paperless-NGX outage rather than a
+    bug — connection failures, timeouts, and 5xx responses.
+
+    Paperless-NGX is briefly unreachable while it restarts or runs its nightly
+    maintenance tasks. Those blips are expected and self-heal on the next tick,
+    so callers log a single concise warning instead of a full traceback and
+    keep retrying. Genuine/unexpected errors still surface loudly.
+    """
+    if isinstance(exc, httpx.TransportError):
+        # ConnectError ("All connection attempts failed"), timeouts, protocol
+        # errors, pool exhaustion — all subclasses of TransportError.
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code >= 500
+    return False
+
+
+async def _purge_deleted_document(vs: Any, doc_id: int) -> None:
+    """Remove all local trace of a document that no longer exists in Paperless.
+
+    Called when a re-embed flush gets a 404 for the document: the document was
+    deleted in Paperless-NGX, so its vector and its tracking row are stale.
+    Dropping both stops the row being retried forever (it would re-log the same
+    404 on every daily flush) and keeps the deleted document out of Discovery
+    search results.
+    """
+    try:
+        await vs.delete(doc_id)
+    except Exception:
+        logger.warning("Failed to purge vector for deleted doc %d", doc_id, exc_info=True)
+    async with AsyncSessionLocal() as db:
+        t = await db.get(DocumentTrackingORM, doc_id)
+        if t:
+            await db.delete(t)
+            await db.commit()
+    logger.info(
+        "Re-embed flush: document %d no longer exists in Paperless — "
+        "dropped stale tracking row and vector.",
+        doc_id,
+    )
+
+
 async def _flush_dirty_reembeds(vs: Any, pc: Any) -> None:
     """Re-embed all documents marked dirty (reembed_dirty_since IS NOT NULL)."""
     async with AsyncSessionLocal() as db:
@@ -829,6 +884,7 @@ async def _flush_dirty_reembeds(vs: Any, pc: Any) -> None:
 
     logger.info("Re-embed flush: processing %d dirty document(s).", len(dirty_rows))
     flushed = 0
+    purged = 0
     for tracking in dirty_rows:
         doc_id = tracking.document_id
         try:
@@ -865,9 +921,31 @@ async def _flush_dirty_reembeds(vs: Any, pc: Any) -> None:
                     await db.commit()
             await _record_document_embed(doc_id, doc.get("title"), "system:flush")
             flushed += 1
-        except Exception:
-            logger.warning("Re-embed flush failed for doc %d", doc_id, exc_info=True)
-    logger.info("Re-embed flush complete: %d/%d documents re-embedded.", flushed, len(dirty_rows))
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                # Document deleted in Paperless — drop the stale row + vector so
+                # it stops being retried on every flush.
+                await _purge_deleted_document(vs, doc_id)
+                purged += 1
+            elif _is_transient_paperless_error(exc):
+                logger.warning(
+                    "Re-embed flush: Paperless returned %d for doc %d; will retry.",
+                    exc.response.status_code, doc_id,
+                )
+            else:
+                logger.warning("Re-embed flush failed for doc %d", doc_id, exc_info=True)
+        except Exception as exc:
+            if _is_transient_paperless_error(exc):
+                logger.warning(
+                    "Re-embed flush: Paperless unreachable for doc %d (%s); will retry.",
+                    doc_id, type(exc).__name__,
+                )
+            else:
+                logger.warning("Re-embed flush failed for doc %d", doc_id, exc_info=True)
+    logger.info(
+        "Re-embed flush complete: %d/%d re-embedded, %d stale document(s) purged.",
+        flushed, len(dirty_rows), purged,
+    )
 
 
 def _parse_paperless_dt(value: str | None) -> datetime | None:

--- a/tests/test_embed_refresh.py
+++ b/tests/test_embed_refresh.py
@@ -19,9 +19,13 @@ from backend.orm_models import DocumentTrackingORM
 class SpyVectorStore:
     def __init__(self) -> None:
         self.upserts: list[tuple[int, str, dict]] = []
+        self.deletes: list[int] = []
 
     async def upsert(self, doc_id: int, text: str, metadata: dict) -> None:
         self.upserts.append((doc_id, text, metadata))
+
+    async def delete(self, doc_id: int) -> None:
+        self.deletes.append(doc_id)
 
 
 def _tracking_row(doc_id: int = 7) -> DocumentTrackingORM:
@@ -145,6 +149,100 @@ async def test_flush_dirty_reembeds_upserts_and_clears_marker(db_engine, monkeyp
     async with factory() as session:
         row = await session.get(DocumentTrackingORM, 7)
         assert row.reembed_dirty_since is None  # marker cleared after flush
+
+
+@pytest.mark.asyncio
+async def test_flush_dirty_reembeds_purges_deleted_document(db_engine, monkeypatch) -> None:
+    """A dirty doc that 404s (deleted in Paperless) has its tracking row and
+    vector dropped, so it is not retried on every future flush."""
+    import httpx
+
+    import backend.main as m
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    monkeypatch.setattr(m, "AsyncSessionLocal", factory)
+
+    async with factory() as session:
+        row = _tracking_row(7)
+        row.reembed_dirty_since = datetime.now(timezone.utc)
+        session.add(row)
+        await session.commit()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Only the entity-lookup calls reach the mock transport; the per-doc
+        # fetch 404s from FakePC below before any metadata request is made.
+        return httpx.Response(200, json={"results": [], "next": None})
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.AsyncClient
+
+    def patched_client(**kwargs):
+        kwargs.pop("transport", None)
+        return real_client(transport=transport, **kwargs)
+
+    monkeypatch.setattr("backend.main.httpx.AsyncClient", patched_client)
+
+    class DeletedPC:
+        _base_url = "http://paperless.test"
+        _headers: dict = {}
+
+        async def get_document_ocr_text(self, doc_id: int) -> str:
+            request = httpx.Request("GET", f"{self._base_url}/api/documents/{doc_id}/")
+            raise httpx.HTTPStatusError(
+                "Not Found", request=request, response=httpx.Response(404, request=request)
+            )
+
+    vs = SpyVectorStore()
+    await m._flush_dirty_reembeds(vs, DeletedPC())
+
+    assert vs.upserts == []           # nothing re-embedded
+    assert vs.deletes == [7]          # vector purged
+    async with factory() as session:
+        assert await session.get(DocumentTrackingORM, 7) is None  # tracking row dropped
+
+
+@pytest.mark.asyncio
+async def test_flush_dirty_reembeds_keeps_row_on_transient_error(db_engine, monkeypatch) -> None:
+    """A transient outage (ConnectError) leaves the dirty row intact for retry —
+    it must NOT be purged like a 404."""
+    import httpx
+
+    import backend.main as m
+
+    factory = async_sessionmaker(bind=db_engine, expire_on_commit=False)
+    monkeypatch.setattr(m, "AsyncSessionLocal", factory)
+
+    async with factory() as session:
+        row = _tracking_row(7)
+        row.reembed_dirty_since = datetime.now(timezone.utc)
+        session.add(row)
+        await session.commit()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"results": [], "next": None})
+
+    transport = httpx.MockTransport(handler)
+    real_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        "backend.main.httpx.AsyncClient",
+        lambda **kw: real_client(transport=transport, **{k: v for k, v in kw.items() if k != "transport"}),
+    )
+
+    class DownPC:
+        _base_url = "http://paperless.test"
+        _headers: dict = {}
+
+        async def get_document_ocr_text(self, doc_id: int) -> str:
+            raise httpx.ConnectError("All connection attempts failed")
+
+    vs = SpyVectorStore()
+    await m._flush_dirty_reembeds(vs, DownPC())
+
+    assert vs.deletes == []  # NOT purged — outage is transient
+    async with factory() as session:
+        row = await session.get(DocumentTrackingORM, 7)
+        assert row is not None
+        assert row.reembed_dirty_since is not None  # still dirty, will retry
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -634,34 +634,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -2107,7 +2107,7 @@ wheels = [
 
 [[package]]
 name = "paperless-iq"
-version = "1.0.0"
+version = "1.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Problem

Container logs surfaced two long-running annoyances in the Paperless-NGX integration:

- **Stale re-embed rows accumulate.** When a document is deleted in Paperless, its `reembed_dirty_since` row remained. `get_document_ocr_text` 404s, throwing into the broad `except` in `_flush_dirty_reembeds` — logged, but the dirty flag was never cleared. Result: the *same* 404 re-logged on every daily 06:00 flush (e.g. doc 2450 for a week straight), and each deleted-but-dirty doc piles up forever.
- **Maintenance-window noise.** Paperless-NGX is briefly unreachable during nightly maintenance / restarts. The inbox poll loop and background index caught the resulting `ConnectError`/5xx and dumped a full traceback via `logger.exception`, making a routine blip look like a crash.

## Changes

1. **Purge deleted documents.** A definite `404` in the flush now calls `_purge_deleted_document`: removes the vector (`vs.delete`) and deletes the `document_tracking` row. Stops the retry loop and keeps deleted docs out of Discovery search. Transient `5xx`/connect errors are distinguished and **keep** the row for retry.
2. **Quiet transient outages.** New `_is_transient_paperless_error` classifies `httpx.TransportError` (ConnectError, timeouts, pool/protocol errors) and 5xx responses as transient. The inbox poll loop, background index, and flush log a single concise WARNING and retry on the next tick. Genuine/unexpected errors still log loudly with a traceback.

## Tests

- `test_flush_dirty_reembeds_purges_deleted_document` — 404 → vector deleted + tracking row dropped.
- `test_flush_dirty_reembeds_keeps_row_on_transient_error` — ConnectError → row stays dirty, not purged.

Full suite: 369 passed. `ruff check backend` clean, bandit (medium) clean. No schema change (no Alembic), no design-decision change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)