### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paperless-iq-frontend",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paperless-iq"
-version = "1.1.0"
+version = "1.1.1"
 description = "AI-powered metadata suggestions for Paperless NGX"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Patch release. Everything since v1.1.0 is dependency bumps plus two internal fixes:

- #115 — reembed: drop stale rows for deleted docs; quiet transient NGX outages
- #116 — clear all 16 Dependabot security alerts

No user-facing feature changes, hence a patch bump.

Version bumped in `pyproject.toml` and `frontend/package.json` (kept in sync per release process).

Gates run locally: ruff ✅, bandit ✅, tsc ✅, eslint ✅, check:i18n ✅, pytest 369 passed ✅.

After merge, tag `origin/main` as `v1.1.1` to fire the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)