### PR TITLE
fix(frontend): resolve newly-disclosed brace-expansion/postcss audit findings

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3365,9 +3365,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary
- `npm audit` started failing CI on every open frontend-touching PR after a new advisory (GHSA-rgw5-rvv9-x895, brace-expansion, high) was published for a transitive dev-dependency, plus an existing moderate postcss finding (GHSA-fxqj-rqcc-2cmp)
- `npm audit fix` resolves both with no direct dependency changes — `frontend/package-lock.json` only

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run check:i18n` — clean
- [x] `npm audit --audit-level=low` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ckZ73GLMYsMVQT4vadp7e