### PR TITLE
build: exclude .claude from the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,10 @@ data/
 *.db
 .kiro
 tests/
+
+# Claude Code session state. .claude/worktrees holds full checkouts of the repo
+# (2.6 GB locally at the time of writing), so leaving it in means every local
+# `docker build` streams gigabytes of unrelated data to the daemon before the
+# first layer runs. CI checks out clean and never sees this, which is exactly
+# why it went unnoticed.
+.claude


### PR DESCRIPTION
## What

Adds `.claude` to `.dockerignore`.

## Why

`.claude/worktrees` holds full checkouts of the repo — **2.6 GB** in my local clone — and was not ignored. Any local `docker build` therefore streamed ~2.6 GB of unrelated data to the Docker daemon before the first layer could run.

Found while wiring up a build-from-source setup for the local Paperless stack: the build context was 2.9 GB, of which ~90% was Claude Code session state.

## Scope

Local and self-hosted builds only. CI and the release workflow check out clean, never create `.claude`, and so never saw this — which is exactly why it went unnoticed.

No runtime change; nothing the Dockerfile copies is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDjioM4Z1E6zyQwWh1sKd3